### PR TITLE
fixed the url in the a tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,8 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <meta http-equiv="Permissions-Policy" content="interest-cohort=()"/>
+
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -18,7 +18,7 @@
       "sizes": "512x512"
     }
   ],
-  "start_url": ".",
+  "start_url": "/",
   "display": "standalone",
   "theme_color": "#000000",
   "background_color": "#ffffff"

--- a/src/components/InfoBar/InfoBar.jsx
+++ b/src/components/InfoBar/InfoBar.jsx
@@ -10,7 +10,7 @@ const InfoBar = ({room})=>{
         </div>
         
         <div className="rightInnerContainer">
-            <a href="/"><img src={""} alt="closeImg"/></a>
+            <a href="https://toth2000.github.io/chatBit/"><img src={""} alt="closeImg"/></a>
         </div>
     </div>
     );

--- a/src/components/Join/Join.jsx
+++ b/src/components/Join/Join.jsx
@@ -1,6 +1,6 @@
-import React, { Component, useState } from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import './Join.css'
+import './Join.css';
 
 const Join = () => {
   const [ name, setName ] = useState('');

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import  ReactDOM  from 'react-dom';
-import App from './app';
+import ReactDOM from 'react-dom';
+import App from './App';
 
 ReactDOM.render(
     <App/>,


### PR DESCRIPTION
Fixed #1 + more

added a few more things on the list for functionality 


FLoC Policy - chrome console was spitting out an error when I was testing  - the new code was placed in the head of the index.html to remove the error. 
<meta http-equiv="Permissions-Policy" content="interest-cohort=()"/>
If you want to read up on it see - https://github.community/t/i-have-no-idea-what-the-interest-cohort-is/179780


I set the start_url of the manifest.json to be the root of the site. If you want to read up on this - https://stackoverflow.com/questions/45412014/how-do-i-set-the-start-url-of-a-manifest-json-to-be-the-root-of-the-site

"start_url": "/"

Import {Component} was declared but never read - on saving my editor removed it - it did not harm the code. 

Also added a closing semi-colon to import './Join.css';


Added the correct App import - import App from './App'; - it was lowercased and not compiling. 



